### PR TITLE
xrviz.example()

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ pip install git+https://github.com/intake/xrviz --no-deps
 
 ### Using Pip
 ```
-pip install git+https://github.com/intake/xrviz.git
+pip install git+https://github.com/intake/xrviz
 ```
 
 ### Usage

--- a/xrviz/__init__.py
+++ b/xrviz/__init__.py
@@ -1,5 +1,3 @@
-from . import sample_data
-
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
@@ -20,6 +18,7 @@ def example(show=True):
             ```
     """
     import xarray as xr
+    from . import sample_data
     from . import dashboard
     ds = sample_data.great_lakes
     dash = dashboard.Dashboard(ds)

--- a/xrviz/__init__.py
+++ b/xrviz/__init__.py
@@ -6,6 +6,19 @@ del get_versions
 
 
 def example(show=True):
+    """
+    Generates interface for the sample dataset.
+
+    Parameters
+    ----------
+    show: True (by default): Directly opens the interface in a browser
+          False : Returns the interface(dashboard) object
+            Usage:
+            ```
+            dash = xrviz.example(show = False)
+            dash.panel  # To display interface in Jupyter Notebook
+            ```
+    """
     import xarray as xr
     from . import dashboard
     ds = sample_data.great_lakes

--- a/xrviz/__init__.py
+++ b/xrviz/__init__.py
@@ -5,9 +5,9 @@ __version__ = get_versions()['version']
 del get_versions
 
 
-def example():
+def example(show=True):
     import xarray as xr
     from . import dashboard
     ds = sample_data.great_lakes
     dash = dashboard.Dashboard(ds)
-    dash.show()
+    return dash.show() if show else dash

--- a/xrviz/__init__.py
+++ b/xrviz/__init__.py
@@ -9,17 +9,16 @@ def example(show=True):
 
     Parameters
     ----------
-    show: True (by default): Directly opens the interface in a browser
-          False : Returns the interface(dashboard) object
-            Usage:
-            ```
-            dash = xrviz.example(show = False)
-            dash.panel  # To display interface in Jupyter Notebook
-            ```
+    show: bool (True)
+        Whether to directly execute the interface. If True, a new browser tab
+        will be opened, and the function will block until interrupted. If
+        False, the Dashboard instance is returned without being executed.
     """
     import xarray as xr
     from . import sample_data
     from . import dashboard
     ds = sample_data.great_lakes
     dash = dashboard.Dashboard(ds)
-    return dash.show() if show else dash
+    if show:
+        dash.show()
+    return dash

--- a/xrviz/__init__.py
+++ b/xrviz/__init__.py
@@ -3,3 +3,11 @@ from . import sample_data
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
+
+
+def example():
+    import xarray as xr
+    from . import dashboard
+    ds = sample_data.great_lakes
+    dash = dashboard.Dashboard(ds)
+    dash.show()

--- a/xrviz/tests/test_example.py
+++ b/xrviz/tests/test_example.py
@@ -1,0 +1,7 @@
+from .. import example
+from xrviz.dashboard import Dashboard
+
+
+def test_dashboard_example():
+    dash = example(False)
+    assert isinstance(dash, Dashboard)


### PR DESCRIPTION
As mentioned [here](https://github.com/intake/xrviz/pull/18#discussion_r298709296), the command 
```
python -c "import xrviz; xrviz.example()"
``` 
can now run example.

@martindurant Shall I also delete the examples folder or are there any plans to add more examples?