### PR TITLE
Change holoviews version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 panel
+holoviews==1.12.1
 hvplot
 xarray
 netcdf4

--- a/xrviz/fields.py
+++ b/xrviz/fields.py
@@ -43,6 +43,7 @@ class Fields(SigSlot):
         self.panel = pn.Row(pn.Column('### Plot Dimensions',
                                       self.x, self.y,
                                       background='rgb(175,175,175)'),
+                            pn.Spacer(),
                             pn.Column('### Aggregations',
                                       self.agg_selectors,
                                       background='rgb(175,175,175)'),
@@ -130,13 +131,14 @@ class Fields(SigSlot):
         #         [0] Markdown(str)     --> self.panel[0][0]
         #         [1] Select(name='x',) --> self.panel[0][1]
         #         [2] Select(name='y',) --> self.panel[0][2]
-        #     [1] Column(background='rgb(175,175,175)')
+        #     [1] Spacer(width=20)
+        #     [2] Column(background='rgb(175,175,175)')
         #         [0] Markdown(str)     --> self.panel[1][0]
         #         [1] Column            --> self.panel[1][1]
         #             [0] Select()
         #             [1] Select()
         out = {p.name: p.value for p in self.panel[0][1:]}  # since panel[0][0] is Markdown
-        selectors = {p.name: p.value for p in self.panel[1][1]}  # remaining_dims
+        selectors = {p.name: p.value for p in self.panel[2][1]}  # remaining_dims
         out.update(selectors)
         dims_to_select_animate = [dim for dim, agg in selectors.items() if agg in ['select', 'animate']]
         dims_to_agg = [dim for dim in selectors if dim not in dims_to_select_animate]

--- a/xrviz/tests/test_fields.py
+++ b/xrviz/tests/test_fields.py
@@ -1,4 +1,5 @@
 import pytest
+import panel as pn
 from xrviz.fields import Fields
 from . import data
 
@@ -21,4 +22,5 @@ def test_fields_initial(fields):
     assert fields.y.value is None
     assert fields.panel.name == 'Axes'
     assert fields.panel[0][0].object == '### Plot Dimensions'
-    assert fields.panel[1][0].object == '### Aggregations'
+    assert isinstance(fields.panel[1], pn.Spacer)
+    assert fields.panel[2][0].object == '### Aggregations'


### PR DESCRIPTION
I have change added `holoviews 1.12.1` in requirements.txt

There is a minor problem that a pip user will face once we have `holoviews 1.12.1`:
Doing `python setup.py install` or `pip install xrviz` will show everything except projection panel.
To view projection, doing `conda install geoviews` will again upgrade `holoviews`, as a result of which correct lat/lon will not be displayed. 

To correctly display lat/lon, `pip install holoviews==1.12.1` would be required.
So both `conda install geoviews` and `pip install holoviews==1.12.1` should be done if installed xrviz via pip.

Everything works fine for conda, if default correct dependencies are present.