### PR TITLE
Change displayer width policy to min

### DIFF
--- a/xrviz/display.py
+++ b/xrviz/display.py
@@ -25,9 +25,9 @@ class Display(SigSlot):
     def __init__(self, data):
         super().__init__()
         self.data = data
-        self.select = pn.widgets.MultiSelect(size=8, min_width=300,
+        self.select = pn.widgets.MultiSelect(size=8, max_width=300,
                                              height=210,
-                                             width_policy='min',
+                                             width_policy='max',
                                              name='Variables')
         # self.set_selection(self.data)
         self.set_variables()

--- a/xrviz/templates/variable.html
+++ b/xrviz/templates/variable.html
@@ -102,6 +102,7 @@
         }
         
         th, td {
+          vertical-align: top;
           text-align: left;
           padding: 4px;
         }


### PR DESCRIPTION
The variable displayer in `Variables panel` automatically kept on expanding if the variable is longer in length(ex most variables in HRRR data), since with policy was initially `max`. This has been changed to minimum. 