### PR TITLE
Handle dask arrays

### DIFF
--- a/xrviz/compatibility.py
+++ b/xrviz/compatibility.py
@@ -25,3 +25,10 @@ except ImportError:
         `conda install -c conda-forge metpy pint pooch --no-deps`
     """)
     mpcalc = None
+
+try:
+    import crick
+    has_crick = True
+except ImportError:
+    logger.debug("Install crick to use tdigest method for finding cmap limits.")
+    has_crick = False

--- a/xrviz/compatibility.py
+++ b/xrviz/compatibility.py
@@ -27,8 +27,8 @@ except ImportError:
     mpcalc = None
 
 try:
-    import crick
-    has_crick = True
+    import crick.tdigest
+    has_crick_tdigest = True
 except ImportError:
     logger.debug("Install crick to use tdigest method for finding cmap limits.")
-    has_crick = False
+    has_crick_tdigest = False

--- a/xrviz/dashboard.py
+++ b/xrviz/dashboard.py
@@ -296,6 +296,7 @@ class Dashboard(SigSlot):
         This is used when values selected in `x` and `y` are not data
         coordinates (i.e. one or both values are data dimensions).
         """
+        self.kwargs = self.control.kwargs
         selection = {}  # to collect the value of index selectors
         for i, dim in enumerate(list(self.var_selector_dims)):
             selection[dim] = self.index_selectors[i].value

--- a/xrviz/dashboard.py
+++ b/xrviz/dashboard.py
@@ -188,7 +188,7 @@ class Dashboard(SigSlot):
 
             # It is better to set initial values as 0.1,0.9 rather than 0,1(min, max)
             # to get a color balance graph
-            c_lim_lower, c_lim_upper = (float(cmin), float(cmax)) if cmin and cmax else ([q for q in sel_data_for_cmap.quantile([0.1, 0.9])])
+            c_lim_lower, c_lim_upper = (float(cmin), float(cmax)) if cmin and cmax else ([q for q in sel_data_for_cmap.compute().quantile([0.1, 0.9])])
 
             color_range = {sel_data.name: (c_lim_lower, c_lim_upper)}
 
@@ -283,7 +283,7 @@ class Dashboard(SigSlot):
 
         # It is better to set initial values as 0.1,0.9 rather than 0,1(min, max)
         # to get a color balance graph
-        c_lim_lower, c_lim_upper = (float(cmin), float(cmax)) if cmin and cmax else ([q for q in sel_data.quantile([0.1, 0.9])])
+        c_lim_lower, c_lim_upper = (float(cmin), float(cmax)) if cmin and cmax else ([q for q in sel_data.compute().quantile([0.1, 0.9])])
 
         color_range = {sel_data.name: (c_lim_lower, c_lim_upper)}
 

--- a/xrviz/dashboard.py
+++ b/xrviz/dashboard.py
@@ -15,7 +15,7 @@ import numpy
 from .sigslot import SigSlot
 from .control import Control
 from .utils import convert_widget, player_with_name_and_value, is_float
-from .compatibility import ccrs, gv, gf, has_cartopy, logger
+from .compatibility import ccrs, gv, gf, has_cartopy, logger, has_crick
 
 
 class Dashboard(SigSlot):
@@ -578,7 +578,9 @@ class Dashboard(SigSlot):
 
 def find_cmap_limits(sel_data):
     if isinstance(sel_data.data, dask.array.core.Array):
-        return dask.array.percentile(sel_data.data.ravel(), (10, 90)).compute()
+        method = 'tdigest' if has_crick else 'default'
+        return dask.array.percentile(sel_data.data.ravel(), (10, 90),
+                                     method=method).compute()
     else:  # if sel_data.data is numpy.ndarray
         return [float(q) for q in sel_data.quantile([0.1, 0.9])]
 

--- a/xrviz/dashboard.py
+++ b/xrviz/dashboard.py
@@ -15,7 +15,7 @@ import numpy
 from .sigslot import SigSlot
 from .control import Control
 from .utils import convert_widget, player_with_name_and_value, is_float
-from .compatibility import ccrs, gv, gf, has_cartopy, logger, has_crick
+from .compatibility import ccrs, gv, gf, has_cartopy, logger, has_crick_tdigest
 
 
 class Dashboard(SigSlot):
@@ -578,7 +578,7 @@ class Dashboard(SigSlot):
 
 def find_cmap_limits(sel_data):
     if isinstance(sel_data.data, dask.array.core.Array):
-        method = 'tdigest' if has_crick else 'default'
+        method = 'tdigest' if has_crick_tdigest else 'default'
         return dask.array.percentile(sel_data.data.ravel(), (10, 90),
                                      method=method).compute()
     else:  # if sel_data.data is numpy.ndarray

--- a/xrviz/style.py
+++ b/xrviz/style.py
@@ -28,6 +28,10 @@ class Style(SigSlot):
             - ``lower limit``: auto-filled value equals ``quantile(0.1)`` of values to be plotted.
             - ``upper limit``: auto-filled value equals ``quantile(0.9)`` of values to be plotted.
 
+            In case of dask array, `dask.array.percentile <https://docs.dask.org/en/latest/array-api.html#dask.array.percentile>`_
+            is use to compute the limits. ``tdigest`` method is used in case `crick <https://pypi.org/project/crick/>`_ is present.
+            The value of limits is rounded off to 5 decimal places, for simplicity.
+
             Note that these values are filled with respect to color scaled
             values. Also these limits clear upon change in variable or
             color scaling.

--- a/xrviz/tests/test_dashboard.py
+++ b/xrviz/tests/test_dashboard.py
@@ -4,7 +4,7 @@ from xrviz.dashboard import Dashboard, find_cmap_limits
 import pytest
 from . import data
 from ..utils import _is_coord
-from ..compatibility import has_cartopy, has_crick
+from ..compatibility import has_cartopy, has_crick_tdigest
 
 
 @pytest.fixture(scope='module')
@@ -213,8 +213,8 @@ def test_create_taps_and_series_graph_for_2d_coords(dashboard):
     assert isinstance(dashboard.series_graph[0], pn.pane.holoviews.HoloViews)
 
 
-@pytest.mark.skipif(not has_crick, reason='crick not present')
-def test_find_cmap_limits_with_crick():
+@pytest.mark.skipif(not has_crick_tdigest, reason='crick.tdigest not present')
+def test_find_cmap_limits_with_crick_tdigest():
     ds = xr.tutorial.open_dataset('air_temperature',
                                   chunks={'lat': 25, 'lon': 25, 'time': 10})
     a, b = find_cmap_limits(ds.air)

--- a/xrviz/tests/test_dashboard.py
+++ b/xrviz/tests/test_dashboard.py
@@ -218,4 +218,4 @@ def test_find_cmap_limits_with_crick_tdigest():
     ds = xr.tutorial.open_dataset('air_temperature',
                                   chunks={'lat': 25, 'lon': 25, 'time': 10})
     a, b = find_cmap_limits(ds.air)
-    assert (a, b) == (255.38780056044027, 298.5900340551101)
+    assert abs(a - 255.38780056044027) < 0.1 and abs(b - 298.5900340551101) < 0.1

--- a/xrviz/tests/test_dashboard.py
+++ b/xrviz/tests/test_dashboard.py
@@ -1,10 +1,10 @@
 import xarray as xr
 import panel as pn
-from xrviz.dashboard import Dashboard
+from xrviz.dashboard import Dashboard, find_cmap_limits
 import pytest
 from . import data
 from ..utils import _is_coord
-from ..compatibility import has_cartopy
+from ..compatibility import has_cartopy, has_crick
 
 
 @pytest.fixture(scope='module')
@@ -211,3 +211,11 @@ def test_create_taps_and_series_graph_for_2d_coords(dashboard):
     dashboard.create_graph()
     dashboard.create_taps_graph(x=-79.232, y=43.273)
     assert isinstance(dashboard.series_graph[0], pn.pane.holoviews.HoloViews)
+
+
+@pytest.mark.skipif(not has_crick, reason='crick not present')
+def test_find_cmap_limits_with_crick():
+    ds = xr.tutorial.open_dataset('air_temperature',
+                                  chunks={'lat': 25, 'lon': 25, 'time': 10})
+    a, b = find_cmap_limits(ds.air)
+    assert (a, b) == (255.38780056044027, 298.5900340551101)


### PR DESCRIPTION
Now we can create plot for dask arrays.

```python
import xarray as xr
from xrviz.dashboard import Dashboard

ds = xr.tutorial.open_dataset('air_temperature',
                              chunks={'lat': 25, 'lon': 25, 'time': -1})
dash = Dashboard(ds)
dash.show()
```
The above code now runs without error (on clicking `PLOT`). 

In master branch it gives `TypeError: quantile does not work for arrays stored as dask arrays. Load the data via .compute() or .load() prior to calling this method.`