### PR TITLE
unpin holoviews

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 panel
-holoviews==1.12.1
+holoviews
 hvplot
 xarray
 netcdf4


### PR DESCRIPTION
closes #36 

https://github.com/pyviz/holoviews/issues/3891 was closed about three weeks ago. I don't think this version pin is necessary anymore. 