### PR TITLE
Check metpy version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,7 @@ matrix:
       install:
         - pip install pytest
         - pip install .
-        - pip install Cython==0.29.14
-        - pip install netCDF4==1.5.2
+        - pip install Cython==0.25.2
       script:
         - pytest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
       install:
         - pip install pytest
         - pip install .
-        - pip install Cython==0.25.2
+        - pip install Cython==0.29.13
       script:
         - pytest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ matrix:
         - conda create -c conda-forge -n test python=3.7 pytest --file requirements.txt
         - source activate test
         - pip install . --no-deps
-        - pip install Cython==0.29.14
       script:
         - pytest
 
@@ -28,6 +27,7 @@ matrix:
       install:
         - pip install pytest
         - pip install .
+        - pip install Cython==0.29.14
       script:
         - pytest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ matrix:
         - "3.7"
       install:
         - pip install pytest
+        - pip install Cython==0.29.13 cftime==1.0.4
         - pip install .
-        - pip install Cython==0.29.13
       script:
         - pytest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
       install:
         - pip install pytest
         - pip install .
-        - pip install Cython==0.29.14
+        - pip install Cython==0.29.13
       script:
         - pytest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ matrix:
       install:
         - pip install pytest
         - pip install .
-        - pip install Cython==0.29.13
+        - pip install Cython==0.29.14
+        - pip install netCDF4==1.5.2
       script:
         - pytest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
         - conda create -c conda-forge -n test python=3.7 pytest --file requirements.txt
         - source activate test
         - pip install . --no-deps
+        - pip install Cython==0.29.14
       script:
         - pytest
 

--- a/xrviz/fields.py
+++ b/xrviz/fields.py
@@ -1,4 +1,3 @@
-import metpy
 import panel as pn
 from packaging.version import Version
 import xarray as xr
@@ -243,6 +242,7 @@ class Fields(SigSlot):
         .. _`metpy.parse_cf`: https://github.com/Unidata/MetPy/blob/master/metpy/xarray.py#L335
         """
         try:
+            import metpy
             parsed_var = self.data.metpy.parse_cf(var)
             if(Version(metpy.__version__)) > Version("0.12"):
                 x, y = parsed_var.metpy.longitude, parsed_var.metpy.latitude 

--- a/xrviz/fields.py
+++ b/xrviz/fields.py
@@ -1,4 +1,6 @@
+import metpy
 import panel as pn
+from packaging.version import Version
 import xarray as xr
 import warnings
 from .sigslot import SigSlot
@@ -242,7 +244,10 @@ class Fields(SigSlot):
         """
         try:
             parsed_var = self.data.metpy.parse_cf(var)
-            x, y = parsed_var.metpy.coordinates('x', 'y')
+            if(Version(metpy.__version__)) > Version("0.12"):
+                x, y = parsed_var.metpy.longitude, parsed_var.metpy.latitude 
+            else:
+                x, y = parsed_var.metpy.coordinates('x', 'y') 
             return [coord.name for coord in (x, y)]
         except:  # fails when coords have not been set or available.
             return [None, None]

--- a/xrviz/fields.py
+++ b/xrviz/fields.py
@@ -1,5 +1,5 @@
 import panel as pn
-from packaging.version import Version
+from distutils.version import LooseVersion
 import xarray as xr
 import warnings
 from .sigslot import SigSlot
@@ -244,10 +244,12 @@ class Fields(SigSlot):
         try:
             import metpy
             parsed_var = self.data.metpy.parse_cf(var)
-            if(Version(metpy.__version__)) > Version("0.12"):
+            if(LooseVersion(metpy.__version__) > LooseVersion("0.12.9")):
                 x, y = parsed_var.metpy.longitude, parsed_var.metpy.latitude 
             else:
-                x, y = parsed_var.metpy.coordinates('x', 'y') 
+                with warnings.catch_warnings():
+                    warnings.filterwarnings("ignore", category = DeprecationWarning)
+                    x, y = parsed_var.metpy.coordinates('x', 'y')
             return [coord.name for coord in (x, y)]
         except:  # fails when coords have not been set or available.
             return [None, None]


### PR DESCRIPTION
Since `metpy 1.0` uses 
```
x, y = parsed_var.metpy.longitude, parsed_var.metpy.latitude 
```

instead of 
```
x, y = parsed_var.metpy.coordinates('x', 'y')
``` 
as in previous versions, a version check has been added.